### PR TITLE
feat: create barca cloud sdk integration base for node.js

### DIFF
--- a/lib/bwc.js
+++ b/lib/bwc.js
@@ -1,0 +1,5 @@
+require('./modules')
+
+var BWC = require('./core')
+
+module.exports = BWC;

--- a/lib/core.js
+++ b/lib/core.js
@@ -1,0 +1,3 @@
+var BWC = { util: require('./utils') };
+
+module.exports = BWC;

--- a/lib/modules.js
+++ b/lib/modules.js
@@ -1,0 +1,4 @@
+var util = require('./utils');
+
+util.platform = require('os');
+

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,7 @@
+var util = {
+  platform: function platform() {
+    console.log(os.hostname())
+  },
+}
+
+module.exports = util;

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
     "barca",
     "barca-cloud",
     "bwc",
+    "liarca",
+    "harpia",
+    "mamute",
     "nodejs",
     "javascript",
     "typescript"

--- a/package.json
+++ b/package.json
@@ -1,29 +1,37 @@
 {
-  "name": "@eloajs/core",
+  "name": "bwc",
   "version": "1.0.0",
-  "description": "A Framework Node.js server-side to JavaScript & TypeScript",
+  "description": "BWC for JavaScript & TypeScript",
   "keywords": [
-    "eloajs",
+    "barca",
+    "barca-cloud",
+    "bwc",
     "nodejs",
-    "node",
     "javascript",
     "typescript"
   ],
-  "authors": [
-    "@ahsouza Aníbal Henrique De Souza <anibal.souza@eloajs.org"
-  ],
-  "homepage": "https://github.com/eloajs/core#readme",
-  "bugs": {
-    "url": "https://github.com/eloajs/core/issues",
-    "email": "support@eloajs.org"
+  "author": {
+    "name": "Barca Web Cloud",
+    "url": "https://cloud.barca.com/"
   },
-  "main": "index.js",
+  "contributors": [
+    "Aníbal Henrique <anibalsouza@barca.com>"
+  ],
+  "homepage": "https://github.com/BarcaWebCloud/bwc-js#readme",
+  "bugs": {
+    "url": "https://github.com/BarcaWebCloud/bwc-js/issues",
+    "email": "support@barca.com"
+  },
+  "main": "lib/bwc.js",
+  "directories": {
+    "lib": "lib"
+  },
   "scripts": {
     "test": "mocha"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/eloajs/core.git"
+    "url": "https://github.com/BarcaWebCloud/bwc-js.git"
   },
   "license": "MIT",
   "private": false,


### PR DESCRIPTION
The implementation of the **Barca Web Cloud SDK** for
 to use in **Node.js** environment is being developed. Initially a base of integrations in the utilities of configurations, modules and resources with the core of the project.